### PR TITLE
Added webpack.config file & build key to scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "FEC",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "webpack --watch --config webpack.config.js"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,23 @@
+var path = require('path')
+var SRC = path.join(__dirname, "/client/src/index.js")
+var DIST = path.join(__dirname, "/client/dist")
+
+module.exports = {
+  mode: "development",
+  entry: SRC,
+  output: {
+    filename: "main.js",
+    path: DIST,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?/,
+        loader: "babel-loader",
+        options: {
+          presets: ["@babel/preset-env", "@babel/preset-react"],
+        },
+      },
+    ],
+  },
+};


### PR DESCRIPTION
It's going to look for `.jsx` file to transpile. What should we use for react component files? `.js` or `.jsx` 
I can change to `.js` in `rules`, let me know how you think :) @rickkunz @jcaughern 
``` 
module: {
    rules: [
      {
        test: /\.jsx?/,
        loader: "babel-loader",
        options: {
          presets: ["@babel/preset-env", "@babel/preset-react"],
        },
      },
    ],
  }
```